### PR TITLE
Add instructions for testing the endpoints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,36 +14,51 @@ The following HTTP routes are available from the component:
 /sleep          # Sleep for {ms} milliseconds
 /echo           # Echo the HTTP body
 /echo-headers   # Echo the HTTP headers
-/echo-trailers  # Echo the HTTP trailers
-/upload         # Echo uploaded blob 
+/upload         # Echo uploaded blob
+```
+
+Testing routes:
+
+```bash
+# Hello world
+$ curl localhost:8080
+# Sleep for {ms} milliseconds
+$ curl localhost:8080/sleep/2000
+# Echo the HTTP body
+$ curl -d "Test echo body" localhost:8080/echo
+# Echo the HTTP headers
+$ curl -H "X-Test-Header: 123" localhost:8080/echo-headers
+# Echo uploaded blob
+$ echo "Hello World!" > test_file.txt
+$ curl -H "Content-Type: text/plain" --data-binary @test_file.txt http://localhost:8080/upload
 ```
 
 ## Quick Start
-The project uses [`Wasmtime`][wasmtime] as its runtime. However, if needed, it 
-can easily be adjusted to use [`jco`][jco] instead. For `wasmtime` installation, 
+The project uses [`Wasmtime`][wasmtime] as its runtime. However, if needed, it
+can easily be adjusted to use [`jco`][jco] instead. For `wasmtime` installation,
 simply run:
 
 ```bash
 $ curl https://wasmtime.dev/install.sh -sSf | bash
 ```
 
-The quickest way to start is by using [`just`][just]. 
+The quickest way to start is by using [`just`][just].
 ```bash
 $ just serve # to build and serve the wasm component on `localhost:8080`
-$ curl 127.0.0.1:8080 # to send requests to component.
+$ curl localhost:8080 # to send requests to component.
 ```
 
 Alternatively, run:
 
 ```bash
 $ npm install
-$ npm build
+$ npm run build
 $ wasmtime serve -S common dist/server.component.wasm
 ```
 
 ## See Also
 
-- [sample-wasi-http-rust](https://github.com/bytecodealliance/sample-wasi-http-rust) An example `wasi:http` server component written in Rust.
+- [sample-wasi-http-rust][rust-sample] An example `wasi:http` server component written in Rust.
 
 ## License
 
@@ -51,6 +66,6 @@ Apache-2.0 with LLVM Exception
 
 [jco]: https://github.com/bytecodealliance/jco
 [just]: https://github.com/casey/just
-[rust-sample]: https://github.com/bytecodealliance/sample-wasi-http-rust 
+[rust-sample]: https://github.com/bytecodealliance/sample-wasi-http-rust
 [wasi-http]: https://github.com/WebAssembly/wasi-http
-[wasmtime]: https://wasmtime.dev/ 
+[wasmtime]: https://wasmtime.dev/

--- a/src/endpoints/echo.js
+++ b/src/endpoints/echo.js
@@ -1,4 +1,4 @@
-export { echo, echoHeaders, echoTrailers };
+export { echo, echoHeaders };
 
 // Echo the body of the request in the response
 const echo = async (req) => {
@@ -16,25 +16,6 @@ const echo = async (req) => {
 const echoHeaders = (req) => {
   const headersObj = Object.fromEntries(req.headers.entries());
   return new Response(JSON.stringify(headersObj, null, 2), {
-    status: 200,
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
-};
-
-// Echo all trailers from the request in JSON format
-const echoTrailers = async (req) => {
-  let trailers;
-  try {
-    trailers = req.trailers ? await req.trailers : new Headers();
-  } catch (e) {
-    console.warning("Error fetching trailers:", e);
-    trailers = new Headers();
-  }
-
-  const trailersObj = Object.fromEntries(trailers.entries());
-  return new Response(JSON.stringify(trailersObj, null, 2), {
     status: 200,
     headers: {
       "Content-Type": "application/json",

--- a/src/server.js
+++ b/src/server.js
@@ -3,14 +3,13 @@ import { AutoRouter } from "itty-router";
 
 import { sleep } from "./endpoints/sleep.js";
 import { upload } from "./endpoints/upload.js";
-import { echo, echoHeaders, echoTrailers } from "./endpoints/echo.js";
+import { echo, echoHeaders } from "./endpoints/echo.js";
 
 let router = AutoRouter();
 
 router
   .get("/", () => new Response("Hello, World!"))
   .get("/echo-headers", (req) => echoHeaders(req))
-  .get("/echo-trailers", (req) => echoTrailers(req))
   .get("/sleep/:ms", async ({ ms }) => await sleep(ms))
   .post("/echo", (req) => echo(req))
   .post("/upload", async (req) => await upload(req));


### PR DESCRIPTION
This also removes echo-trailers endpoint for now as it is not trivially supported by StarlingMonkey so it will always return empty headers.